### PR TITLE
Adds two new tips, add missing comma

### DIFF
--- a/src/main/resources/assets/tips/lang/en_us.json
+++ b/src/main/resources/assets/tips/lang/en_us.json
@@ -47,5 +47,6 @@
   "tips.tip.wandering_invis": "Wandering traders drink invisibility potions at night.",
   "tips.tip.baby_panda_slimeball": "Baby Pandas have a 0.1% chance to drop a slimeball after they sneeze.",
   "tips.tip.fortress_triangulation": "You can use basic triangulation to better find Strongholds. Fire Eyes of Ender from two different locations, and find the spot where the two lines intersect. Even speedrunners use this tactic!",
-  "tips.tip.creeper_drops_disc": "If a Skeleton's or Stray's arrow kills a Creeper, the Creeper drops a random music disc (excluding the nether music disc)."
+  "tips.tip.creeper_drops_disc": "If a Skeleton's or Stray's arrow kills a Creeper, the Creeper drops a random music disc (excluding the nether music disc).",
+  "tips.tip.mooshroom_lightning": "A red mooshroom will become a brown mooshroom, and a brown mooshroom will become a red one, when struck by lightning."
 }

--- a/src/main/resources/assets/tips/lang/en_us.json
+++ b/src/main/resources/assets/tips/lang/en_us.json
@@ -45,6 +45,7 @@
   "tips.tip.job_site_dimension": "Villagers lose their job site when changing dimensions.",
   "tips.tip.villager_sweat": "Villagers sweat when trying to trade with them during a raid.",
   "tips.tip.wandering_invis": "Wandering traders drink invisibility potions at night.",
-  "tips.tip.baby_panda_slimeball": "Baby Pandas have a 0.1% chance to drop a slimeball after they sneeze."
-  "tips.tip.fortress_triangulation": "You can use basic triangulation to better find Strongholds. Fire Eyes of Ender from two different locations, and find the spot where the two lines intersect. Even speedrunners use this tactic!"
+  "tips.tip.baby_panda_slimeball": "Baby Pandas have a 0.1% chance to drop a slimeball after they sneeze.",
+  "tips.tip.fortress_triangulation": "You can use basic triangulation to better find Strongholds. Fire Eyes of Ender from two different locations, and find the spot where the two lines intersect. Even speedrunners use this tactic!",
+  "tips.tip.creeper_drops_disc": "If a Skeleton's or Stray's arrow kills a Creeper, the Creeper drops a random music disc (excluding the nether music disc)."
 }

--- a/src/main/resources/assets/tips/tips/creeper_drops_disc.json
+++ b/src/main/resources/assets/tips/tips/creeper_drops_disc.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tips.tip.creeper_drops_disc"
+  }
+}

--- a/src/main/resources/assets/tips/tips/mooshroom_lightning.json
+++ b/src/main/resources/assets/tips/tips/mooshroom_lightning.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tips.tip.mooshroom_lightning"
+  }
+}


### PR DESCRIPTION
### New tips
 * `creeper_drops_disc`: If a Skeleton's or Stray's arrow kills a Creeper, the Creeper drops a random music disc (excluding the nether music disc).
 * `mooshroom_lightning`: A red mooshroom will become a brown mooshroom, and a brown mooshroom will become a red one, when struck by lightning.

Also fixes a missing comma in `en_us.json` from a previously added tip.

<sup>~~i need the top 5 spot in modtoberfest~~</stop>