### PR TITLE
Fix translation key used for boat passenger tip

### DIFF
--- a/Common/src/main/resources/assets/tipsmod/tips/boat_passenger.json
+++ b/Common/src/main/resources/assets/tipsmod/tips/boat_passenger.json
@@ -1,5 +1,5 @@
 {
   "tip": {
-    "translate": "tipsmod.tip.east"
+    "translate": "tipsmod.tip.boat_passenger"
   }
 }


### PR DESCRIPTION
Currently, the boat passenger tip uses the translation key for the eastward sky movement tip (see also #78). This PR fixes that tip to use the correct translation key of `tipsmod.tip.boat_passenger`.