### PR TITLE
Update pack format to align with Minecraft 1.19

### DIFF
--- a/Common/src/main/resources/pack.mcmeta
+++ b/Common/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "${mod_description}",
-    "pack_format": 8
+    "pack_format": 9
   }
 }

--- a/Common/src/main/resources/pack.mcmeta
+++ b/Common/src/main/resources/pack.mcmeta
@@ -1,6 +1,8 @@
 {
   "pack": {
     "description": "${mod_description}",
-    "pack_format": 9
+    "pack_format": 9,
+    "forge:resource_pack_format": 9,
+    "forge:data_pack_format": 10
   }
 }


### PR DESCRIPTION
This updates the pack format to align with the [_resource_ pack format](https://minecraft.fandom.com/wiki/Resource_Pack#Pack_format) for Minecraft 1.19. Note that the current [_data_ pack format](https://minecraft.fandom.com/wiki/Data_pack#Pack_format) for 1.19 is 10, but I've chosen the lower pack format.

As an additional, this also uses the type-specific pack formats feature added by Forge (MinecraftForge/MinecraftForge#8612) to ensure the pack format is correct when it is loaded either as a resource pack (on the client) or as a data pack (on the server). Because Minecraft/GSON is lenient with the existence of non-deserialized keys, this does not cause any issues with Fabric or other modloaders.

I chose to modify the existing `pack.mcmeta` rather than creating a new one in the Forge subproject because _(a)_ it works inside and outside of Forge, _(b)_ it can be removed without any problems, and _(c)_ it would take more effort than I believe its worth to extract that out to its own `pack.mcmeta` and hunt down the code to modify in support of that new `pack.mcmeta` file in the Force sourceset.