### PR TITLE
Fix translation keys for tips list screen in other languages

### DIFF
--- a/Common/src/main/resources/assets/tipsmod/lang/de_de.json
+++ b/Common/src/main/resources/assets/tipsmod/lang/de_de.json
@@ -80,6 +80,5 @@
   "gui.tips.list.entry.copied":"Kopiert!",
   "gui.tips.list.entry.click_to_copy":"Klicken, um ID zu kopieren",
   "gui.tips.list.entry.disabled":"Eintrag entfernt!",
-  "gui.tips.list.config":"Settings",
-  "gui.tips.list.back":"Zurück"
+  "gui.tips.list.config":"Settings"
 }

--- a/Common/src/main/resources/assets/tipsmod/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/tipsmod/lang/ru_ru.json
@@ -70,14 +70,14 @@
   "tipsmod.tip.freezing_leather": "Кожаная броня может защитить от замораживания.",
   "tipsmod.tip.azalea_caves": "Деревья азалии растут над пышными пещерными биомами.",
   
-  "gui.tipsmod.list.title": "Список советов",
-  "gui.tipsmod.list.search": "Поиск",
-  "gui.tipsmod.list.show_disabled": "Показать отключённые",
-  "gui.tipsmod.list.entry.tip_id": "ID совета: %s",
-  "gui.tipsmod.list.entry.added_by": "Добавлен: %s",
-  "gui.tipsmod.list.entry.cycle_time": "Продолжительность цикла: %s",
-  "gui.tipsmod.list.entry.copied": "Скопирован!",
-  "gui.tipsmod.list.entry.click_to_copy": "Нажми, чтобы скопировать ID",
-  "gui.tipsmod.list.entry.disabled": "Отключено конфигурацией!",
-  "gui.tipsmod.list.config": "Конфигурация"
+  "gui.tips.list.title": "Список советов",
+  "gui.tips.list.search": "Поиск",
+  "gui.tips.list.show_disabled": "Показать отключённые",
+  "gui.tips.list.entry.tip_id": "ID совета: %s",
+  "gui.tips.list.entry.added_by": "Добавлен: %s",
+  "gui.tips.list.entry.cycle_time": "Продолжительность цикла: %s",
+  "gui.tips.list.entry.copied": "Скопирован!",
+  "gui.tips.list.entry.click_to_copy": "Нажми, чтобы скопировать ID",
+  "gui.tips.list.entry.disabled": "Отключено конфигурацией!",
+  "gui.tips.list.config": "Конфигурация"
 }

--- a/Common/src/main/resources/assets/tipsmod/lang/sv_se.json
+++ b/Common/src/main/resources/assets/tipsmod/lang/sv_se.json
@@ -61,14 +61,14 @@
   "tipsmod.tip.blaze_fuel": "Brännstavar kan användas som effektivt bränsle till ugnar.",
   "tipsmod.tip.portal_trick": "Genom att använda lava och vattenhinkar kan man göra en enkel netherportal.",
 
-  "gui.tipsmod.list.title": "Tips Lista",
-  "gui.tipsmod.list.search": "Sök",
-  "gui.tipsmod.list.show_disabled": "Visa Inaktiverade",
-  "gui.tipsmod.list.entry.tip_id": "Tips ID: %s",
-  "gui.tipsmod.list.entry.added_by": "Tillagt av: %s",
-  "gui.tipsmod.list.entry.cycle_time": "Genomloppstid: %s",
-  "gui.tipsmod.list.entry.copied": "Kopierad!",
-  "gui.tipsmod.list.entry.click_to_copy": "Tryck för att kopiera ID",
-  "gui.tipsmod.list.entry.disabled": "Inaktiverad av konfigurationen!",
-  "gui.tipsmod.list.config": "Konfiguration"
+  "gui.tips.list.title": "Tips Lista",
+  "gui.tips.list.search": "Sök",
+  "gui.tips.list.show_disabled": "Visa Inaktiverade",
+  "gui.tips.list.entry.tip_id": "Tips ID: %s",
+  "gui.tips.list.entry.added_by": "Tillagt av: %s",
+  "gui.tips.list.entry.cycle_time": "Genomloppstid: %s",
+  "gui.tips.list.entry.copied": "Kopierad!",
+  "gui.tips.list.entry.click_to_copy": "Tryck för att kopiera ID",
+  "gui.tips.list.entry.disabled": "Inaktiverad av konfigurationen!",
+  "gui.tips.list.config": "Konfiguration"
 }

--- a/Common/src/main/resources/assets/tipsmod/lang/zh_cn.json
+++ b/Common/src/main/resources/assets/tipsmod/lang/zh_cn.json
@@ -59,14 +59,15 @@
   "tipsmod.tip.piglin_repellent": "猪灵害怕灵魂火，包括灵魂火把和灵魂灯笼。",
   "tipsmod.tip.portal_trick": "使用水桶和熔岩桶，你可以轻松建造一个下界传送门。",
   "tipsmod.tip.blaze_fuel": "对熔炉来说，烈焰棒是一种不错的燃料。",
-  "gui.tipsmod.list.title": "提示列表",
-  "gui.tipsmod.list.search": "搜索",
-  "gui.tipsmod.list.show_disabled": "显示被禁用的提示",
-  "gui.tipsmod.list.entry.tip_id": "提示ID：%s",
-  "gui.tipsmod.list.entry.added_by": "提示来自：%s",
-  "gui.tipsmod.list.entry.cycle_time": "循环时间：%s",
-  "gui.tipsmod.list.entry.copied": "已复制！",
-  "gui.tipsmod.list.entry.click_to_copy": "单击以复制ID",
-  "gui.tipsmod.list.entry.disabled": "被配置禁用！",
-  "gui.tipsmod.list.config": "配置"
+
+  "gui.tips.list.title": "提示列表",
+  "gui.tips.list.search": "搜索",
+  "gui.tips.list.show_disabled": "显示被禁用的提示",
+  "gui.tips.list.entry.tip_id": "提示ID：%s",
+  "gui.tips.list.entry.added_by": "提示来自：%s",
+  "gui.tips.list.entry.cycle_time": "循环时间：%s",
+  "gui.tips.list.entry.copied": "已复制！",
+  "gui.tips.list.entry.click_to_copy": "单击以复制ID",
+  "gui.tips.list.entry.disabled": "被配置禁用！",
+  "gui.tips.list.config": "配置"
 }


### PR DESCRIPTION
This PR fixes the translation keys for the tips list screen in the other language files by correcting the `tipsmod` to `tips`, as seen in the English language file.

Additionally, this also deletes the `gui.tips.list.back` translation key in the `de_de` (German) language file, as it is not present in the English language file and unused.