### PR TITLE
Disable tips missing translation for selected language.

### DIFF
--- a/Common/src/main/java/net/darkhax/tipsmod/api/TipsAPI.java
+++ b/Common/src/main/java/net/darkhax/tipsmod/api/TipsAPI.java
@@ -14,8 +14,10 @@ import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.client.gui.screens.ProgressScreen;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
+import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentContents;
+import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.HashMap;
@@ -74,6 +76,25 @@ public class TipsAPI {
         if (TipsModCommon.CONFIG.ignoredTips.contains(id.toString())) {
 
             return false;
+        }
+
+        final ComponentContents contents = tip.getText().getContents();
+
+        if (contents instanceof TranslatableContents) {
+
+            final String key = ((TranslatableContents) contents).getKey();
+
+            // Disable tips missing translation for selected language.
+            if (!TipsModCommon.CONFIG.useAmericanEnglishAsDefault && !TipsModCommon.TIP_MANAGER.getSelectedLanguage().has(key)) {
+
+                return false;
+            }
+
+            // Disable tips missing any translation. Should never happen, but just in case I guess.
+            if (!I18n.exists(key)) {
+
+                return false;
+            }
         }
 
         return true;

--- a/Common/src/main/java/net/darkhax/tipsmod/impl/Config.java
+++ b/Common/src/main/java/net/darkhax/tipsmod/impl/Config.java
@@ -24,6 +24,9 @@ public class Config {
     @Expose
     public List<String> ignoredTips = new ArrayList<>();
 
+    @Expose
+    public boolean useAmericanEnglishAsDefault = false;
+
     public static Config load() {
 
         File configFile = Services.PLATFORM.getConfigPath().resolve("tips.json").toFile();

--- a/Common/src/main/java/net/darkhax/tipsmod/impl/resources/TipManager.java
+++ b/Common/src/main/java/net/darkhax/tipsmod/impl/resources/TipManager.java
@@ -1,6 +1,5 @@
 package net.darkhax.tipsmod.impl.resources;
 
-import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -10,7 +9,9 @@ import net.darkhax.tipsmod.impl.Constants;
 import net.darkhax.tipsmod.api.TipsAPI;
 import net.darkhax.tipsmod.api.resources.ITip;
 import net.darkhax.tipsmod.api.resources.ITipSerializer;
-import net.darkhax.tipsmod.impl.TipsModCommon;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.language.ClientLanguage;
+import net.minecraft.client.resources.language.LanguageInfo;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
@@ -28,6 +29,8 @@ public class TipManager extends SimpleJsonResourceReloadListener {
     private final List<ITip> randomAccess = new ArrayList<>();
     private final List<ITip> immutableAccess = Collections.unmodifiableList(randomAccess);
 
+    private ClientLanguage selectedLanguage;
+
     public TipManager() {
 
         super(new Gson(), "tips");
@@ -38,11 +41,18 @@ public class TipManager extends SimpleJsonResourceReloadListener {
         return this.immutableAccess;
     }
 
+    public ClientLanguage getSelectedLanguage() {
+        return this.selectedLanguage;
+    }
+
     @Override
     protected void apply(Map<ResourceLocation, JsonElement> map, ResourceManager resourceManager, ProfilerFiller profilerFiller) {
 
         this.loadedTips.clear();
         this.randomAccess.clear();
+
+        final LanguageInfo selectedLanguageInfo = Minecraft.getInstance().getLanguageManager().getSelected();
+        this.selectedLanguage = ClientLanguage.loadFrom(resourceManager, Collections.singletonList(selectedLanguageInfo));
 
         final long startTime = System.nanoTime();
 


### PR DESCRIPTION
While thinking about tips to contribute to this mod, I noticed that some of tips were missing translations in the different languages. I don't know any languages other than English well enough to translate them, so instead I thought of this.

This PR automatically disables tips that are missing a translation for the player's selected language. It also adds a new config setting for using the English translation for missing translations (what happens before this PR).

![image](https://user-images.githubusercontent.com/29845000/194101570-d0fa22bc-fcfc-4bd8-bc15-51ee39a2f844.png)
