### PR TITLE
Add registerTipScreen to TipsAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 # other
 eclipse
 run
+.DS_Store

--- a/Common/src/main/java/net/darkhax/tipsmod/api/TipsAPI.java
+++ b/Common/src/main/java/net/darkhax/tipsmod/api/TipsAPI.java
@@ -6,13 +6,6 @@ import net.darkhax.tipsmod.api.resources.ITipSerializer;
 import net.darkhax.tipsmod.impl.TipsModCommon;
 import net.darkhax.tipsmod.impl.resources.SimpleTip;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.gui.screens.ConnectScreen;
-import net.minecraft.client.gui.screens.DeathScreen;
-import net.minecraft.client.gui.screens.DisconnectedScreen;
-import net.minecraft.client.gui.screens.GenericDirtMessageScreen;
-import net.minecraft.client.gui.screens.LevelLoadingScreen;
-import net.minecraft.client.gui.screens.PauseScreen;
-import net.minecraft.client.gui.screens.ProgressScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
@@ -20,10 +13,7 @@ import net.minecraft.network.chat.ComponentContents;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceLocation;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public class TipsAPI {
 
@@ -31,15 +21,21 @@ public class TipsAPI {
     public static final Component DEFAULT_TITLE = Component.translatable("tipsmod.title.default").withStyle(ChatFormatting.BOLD, ChatFormatting.UNDERLINE, ChatFormatting.YELLOW);
     public static final ITip EMPTY = new SimpleTip(new ResourceLocation(Constants.MOD_ID, "empty"), DEFAULT_TITLE, Component.literal("No tips loaded. Please review your config options!"), Optional.of(999999));
     private static Map<ResourceLocation, ITipSerializer<?>> SERIALIZERS = new HashMap<>();
+    private static Set<Class<? extends Screen>> SCREENS = new HashSet<>();
 
     public static void registerTipSerializer(ResourceLocation id, ITipSerializer<?> serializer) {
 
         SERIALIZERS.put(id, serializer);
     }
 
+    public static void registerTipScreen(Class<? extends Screen> screenClass) {
+
+        SCREENS.add(screenClass);
+    }
+
     public static boolean canRenderOnScreen(Screen screen) {
 
-        return screen instanceof GenericDirtMessageScreen || screen instanceof ConnectScreen || screen instanceof DisconnectedScreen || screen instanceof LevelLoadingScreen || screen instanceof ProgressScreen || screen instanceof PauseScreen || screen instanceof DeathScreen;
+        return SCREENS.stream().filter(clazz -> clazz.isInstance(screen)).count() > 0;
     }
 
     public static ITip getRandomTip() {

--- a/Common/src/main/java/net/darkhax/tipsmod/impl/TipsModCommon.java
+++ b/Common/src/main/java/net/darkhax/tipsmod/impl/TipsModCommon.java
@@ -5,6 +5,7 @@ import net.darkhax.bookshelf.api.registry.RegistryDataProvider;
 import net.darkhax.tipsmod.api.TipsAPI;
 import net.darkhax.tipsmod.impl.resources.SimpleTip;
 import net.darkhax.tipsmod.impl.resources.TipManager;
+import net.minecraft.client.gui.screens.*;
 
 public class TipsModCommon extends RegistryDataProvider {
 
@@ -21,5 +22,13 @@ public class TipsModCommon extends RegistryDataProvider {
         super(Constants.MOD_ID);
         this.resourceListeners.add(() -> TIP_MANAGER, "tip_loader");
         TipsAPI.registerTipSerializer(TipsAPI.DEFAULT_SERIALIZER, SimpleTip.SERIALIZER);
+
+        TipsAPI.registerTipScreen(GenericDirtMessageScreen.class);
+        TipsAPI.registerTipScreen(ConnectScreen.class);
+        TipsAPI.registerTipScreen(DisconnectedScreen.class);
+        TipsAPI.registerTipScreen(LevelLoadingScreen.class);
+        TipsAPI.registerTipScreen(ProgressScreen.class);
+        TipsAPI.registerTipScreen(PauseScreen.class);
+        TipsAPI.registerTipScreen(DeathScreen.class);
     }
 }


### PR DESCRIPTION
This PR adds to the `TipsAPI` a static method `registerTipScreen` that adds screen classes to a list that gets checked to determine whether to render tips on a screen.

The motivation for this PR is to fix #62 by allowing mods to register their own loading screens to render tips on.

I have gone ahead and written an implementation for BCLib that I will PR into BCLib because that's the mod #62 was originally reporting:
![image](https://user-images.githubusercontent.com/29845000/194615436-e94008ec-a1f7-4fa5-b7df-1472307d7670.png)

I am waiting until this PR is merged before creating the PR on BCLib because I want to give you a chance to request changes and I need to know what version this PR will be included in on the maven.