### PR TITLE
Add some new tips

### DIFF
--- a/common/src/main/resources/assets/tipsmod/lang/en_us.json
+++ b/common/src/main/resources/assets/tipsmod/lang/en_us.json
@@ -83,6 +83,11 @@
   "tipsmod.tip.joke.lava": "Like any items, buckets will burn in lava, but not when it is IN the bucket.",
   "tipsmod.tip.joke.skulls": "Wither Skeletons are known to lose their heads.",
   "tipsmod.tip.endermites": "There is a small chance that an Endermite will spawn when an Enderpearl lands.",
+  "tipsmod.tip.enderman_projectiles": "Endermen can not be hit by projectiles.",
+  "tipsmod.tip.locked_repeaters": "Repeaters can be locked and kept in its state by powering the sides of it with another repeater.",
+  "tipsmod.tip.water_doors": "You can place a door underwater to create an air pocket.",
+  "tipsmod.tip.shears_dispenser": "You can put shears in a dispenser to shear sheep.",
+  "tipsmod.tip.sheared_cave_vines": "You can shear the ends of cave vines to stop them from growing.",
 
   "gui.tips.list.title": "Tips List",
   "gui.tips.list.search": "Search",

--- a/common/src/main/resources/assets/tipsmod/tips/enderman_projectiles.json
+++ b/common/src/main/resources/assets/tipsmod/tips/enderman_projectiles.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tipsmod.tip.enderman_projectiles"
+  }
+}

--- a/common/src/main/resources/assets/tipsmod/tips/locked_repeaters.json
+++ b/common/src/main/resources/assets/tipsmod/tips/locked_repeaters.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tipsmod.tip.locked_repeaters"
+  }
+}

--- a/common/src/main/resources/assets/tipsmod/tips/sheared_cave_vines.json
+++ b/common/src/main/resources/assets/tipsmod/tips/sheared_cave_vines.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tipsmod.tip.sheared_cave_vines"
+  }
+}

--- a/common/src/main/resources/assets/tipsmod/tips/shears_dispenser.json
+++ b/common/src/main/resources/assets/tipsmod/tips/shears_dispenser.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tipsmod.tip.shears_dispensers"
+  }
+}

--- a/common/src/main/resources/assets/tipsmod/tips/water_doors.json
+++ b/common/src/main/resources/assets/tipsmod/tips/water_doors.json
@@ -1,0 +1,5 @@
+{
+  "tip": {
+    "translate": "tipsmod.tip.water_doors"
+  }
+}


### PR DESCRIPTION
Adds 5 new tips
- Enderman Projectiles - Tells the player that enderman cant be hit by projectiles
- Locked Repeaters - Tells the player that if a repeater is powered by its side with another repeater it becomes locked in its current state
- Water Doors - Tells players they can user doors underwater for an air pocket
- Shears Dispensers - Tells players they can put shears in a dispenser to shear sheep.
- Sheared Cave Vines - Tells the player they can shear the ends of cave vines to stop them from growing.