### PR TITLE
Fix screen condition only works for Vanilla Screen ID

### DIFF
--- a/common/src/main/java/net/darkhax/tipsmod/impl/resources/ConditionRules.java
+++ b/common/src/main/java/net/darkhax/tipsmod/impl/resources/ConditionRules.java
@@ -99,7 +99,7 @@ public class ConditionRules<T> implements Predicate<T> {
         }
 
         // Match by VanillaScreenIds class
-        else if (ResourceLocation.isValidResourceLocation(rule)) {
+        else if (rule.contains(":")) {
             final ResourceLocation targetScreen = ResourceLocation.tryParse(rule);
             if (targetScreen != null && "minecraft".equalsIgnoreCase(targetScreen.getNamespace())) {
                 return screen -> VanillaScreenIds.is(targetScreen, screen.getClass());


### PR DESCRIPTION
idk but `ResourceLocation.isValidResourceLocation("RecipeScreen") == true`, and even `ResourceLocation.isValidResourceLocation("dev.emi.emi.screen.RecipeScreen") == true`
that's weird...

![image](https://github.com/user-attachments/assets/ba244362-e2d4-4050-b5d4-fecea6d64dbe)

![image](https://github.com/user-attachments/assets/087f4bd5-8341-48b6-a2f8-50efc12087b2)

![image](https://github.com/user-attachments/assets/c5b37244-dc95-4740-88a4-d16b09a895e2)
