### PR TITLE
Backport "Add a config option that prevents tips from displaying on specific screens." to 1.20.1

### DIFF
--- a/common/src/main/java/net/darkhax/tipsmod/api/TipsAPI.java
+++ b/common/src/main/java/net/darkhax/tipsmod/api/TipsAPI.java
@@ -13,9 +13,10 @@ import net.minecraft.client.resources.language.I18n;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.resources.ResourceLocation;
-
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,17 @@ public class TipsAPI {
 
     public static boolean canRenderOnScreen(Screen screen) {
 
-        return SCREENS.stream().anyMatch(clazz -> clazz.isInstance(screen));
+        return canRenderOnScreen(screen.getClass());
+    }
+
+    public static boolean canRenderOnScreen(Class<?> clazz) {
+
+        return SCREENS.contains(clazz) && !TipsModCommon.CONFIG.ignoredScreens.contains(clazz.getCanonicalName());
+    }
+
+    public static Collection<Class<?>> getTipsScreens() {
+
+        return Collections.unmodifiableSet(SCREENS);
     }
 
     @Nullable

--- a/common/src/main/java/net/darkhax/tipsmod/impl/Config.java
+++ b/common/src/main/java/net/darkhax/tipsmod/impl/Config.java
@@ -43,6 +43,9 @@ public class Config {
     @Expose
     public Component defaultTitle = TipsAPI.DEFAULT_TITLE;
 
+    @Expose
+    public List<String> ignoredScreens = new ArrayList<>();
+
     public static Config load() {
 
         File configFile = Services.PLATFORM.getConfigPath().resolve("tips.json").toFile();

--- a/common/src/main/java/net/darkhax/tipsmod/impl/resources/TipManager.java
+++ b/common/src/main/java/net/darkhax/tipsmod/impl/resources/TipManager.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import net.darkhax.bookshelf.api.serialization.Serializers;
+import com.mojang.serialization.JsonOps;
 import net.darkhax.tipsmod.api.TipsAPI;
 import net.darkhax.tipsmod.api.resources.ITip;
 import net.darkhax.tipsmod.api.resources.ITipSerializer;
@@ -78,6 +79,8 @@ public class TipManager extends SimpleJsonResourceReloadListener {
             }
         });
         Collections.shuffle(this.randomAccess);
-        Constants.LOG.debug("Loaded {} tips. Took {}ms.", this.loadedTips.size(), (double) (System.nanoTime() - startTime) / 1000000d);
+        Constants.LOG.info("Loaded {} tips. Took {}ms.", this.loadedTips.size(), (double) (System.nanoTime() - startTime) / 1000000d);
+        Constants.LOG.info("The following screens have been registered to the tips mod.");
+        TipsAPI.getTipsScreens().forEach(screen -> Constants.LOG.info("Screen: '{}' Enabled: '{}'", screen.getCanonicalName(), TipsAPI.canRenderOnScreen(screen)));
     }
 }


### PR DESCRIPTION
Addresses issue #137 in 1.20.1. This is the only change ive brought back however, you may reject it if you plan to update 1.20.1 eventually